### PR TITLE
Fixed blank image issue

### DIFF
--- a/src/components/News.js
+++ b/src/components/News.js
@@ -60,7 +60,11 @@ const News = (props)=>{
                     <div className="row">
                         {articles.map((element) => {
                             return <div className="col-md-4" key={element.url}>
-                                <NewsItem title={element.title ? element.title : ""} description={element.description ? element.description : ""} imageUrl={element.urlToImage} newsUrl={element.url} author={element.author} date={element.publishedAt} source={element.source.name} />
+                                <NewsItem title={element.title ? element.title : ""} description={element.description ? element.description : ""}
+                                    // imageUrl={element.urlToImage} newsUrl={element.url} 
+                                    imageUrl={(element.urlToImage==null || element.urlToImage=="")?"http://mapandan.gov.ph/wp-content/uploads/2018/03/no_image.jpg":element.urlToImage}
+                                    author={element.author} date={element.publishedAt} source={element.source.name} 
+                                />
                             </div>
                         })}
                     </div>


### PR DESCRIPTION
Added a fix where a custom image loads if there is no response for the image from the API (helps maintain continuity in the app rather than a blank space in the image section).